### PR TITLE
Make next callback function arguments optional

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,11 +3,11 @@ import { Request, Response, NextFunction } from 'express';
 
 function wrapAsync(asyncFn: Function) {
   // Handle execption safely during the handling request.
-  const exceptionHandler = async (req: Request, res: Response, next: NextFunction) => {
+  const exceptionHandler = async (req: Request, res: Response, next?: NextFunction) => {
     try {
       return await asyncFn(req, res, next);
     } catch (error) {
-      return next(error);
+      return next!(error);
     }
   };
 


### PR DESCRIPTION
From now on, Route handler or middleware without next function is supported.

Example
```typescript
  @AsyncHandler
  public async onlyReqAndRes(req: express.Request, res: express.Response) {
    res.send("onlyReqAndRes");
  }
```